### PR TITLE
Test Fail for long id type

### DIFF
--- a/MySql.Bug75272.sln
+++ b/MySql.Bug75272.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio 2013
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MySql.Bug75272", "MySql.Bug75272\MySql.Bug75272.csproj", "{53CAFCB7-5CAF-41CB-9321-256F336AF0D8}"
 EndProject

--- a/MySql.Bug75272/App.config
+++ b/MySql.Bug75272/App.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
@@ -11,8 +11,8 @@
       </parameters>
     </defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
       <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"></provider>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
   <system.data>
@@ -22,7 +22,6 @@
     </DbProviderFactories>
   </system.data>
   <connectionStrings>
-    <add name="ProductsEntities" providerName="MySql.Data.MySqlClient"
-        connectionString="server=localhost;port=3306;database=bug75272;uid=admin;password=********"/>
+    <add name="ProductsEntities" providerName="MySql.Data.MySqlClient" connectionString="server=localhost;port=3306;database=bug75272;uid=root;password=root" />
   </connectionStrings>
 </configuration>

--- a/MySql.Bug75272/MySql.Bug75272.csproj
+++ b/MySql.Bug75272/MySql.Bug75272.csproj
@@ -36,11 +36,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">

--- a/MySql.Bug75272/ProductsEntities.cs
+++ b/MySql.Bug75272/ProductsEntities.cs
@@ -43,7 +43,7 @@ namespace MySql.Bug75272
 
     public class category
     {
-        public int id { get; set; }
+        public long id { get; set; }
         public string name { get; set; }
     }
 

--- a/MySql.Bug75272/ProductsEntities.cs
+++ b/MySql.Bug75272/ProductsEntities.cs
@@ -28,15 +28,28 @@ namespace MySql.Bug75272
 
     public class product
     {
-        public int id { get; set; }
+        // Change type int to long generate Bug "FROM (SELECT"
+        public long id { get; set; }
         public string name { get; set; }
         [Required]
         public virtual category category { get; set; }
+    }
+
+    // For especific column select
+    [System.ComponentModel.DataAnnotations.Schema.NotMapped]
+    public class productProxy : product {
+
     }
 
     public class category
     {
         public int id { get; set; }
         public string name { get; set; }
+    }
+
+    // For especific column select
+    [System.ComponentModel.DataAnnotations.Schema.NotMapped]
+    public class categoryProxy : category {
+
     }
 }

--- a/MySql.Bug75272/ProductsTest.cs
+++ b/MySql.Bug75272/ProductsTest.cs
@@ -28,13 +28,20 @@ namespace MySql.Bug75272
 
                 context.Database.Log = q => Console.WriteLine(q);
 
-                var products1 = context.products
-                    .OrderBy(x => x.id)
-                    .Take(10)
-                    .ToList();
+                //var products1 = context.products
+                //    .OrderBy(x => x.id)
+                //    .Take(10)
+                //    .ToList();
                 
                 var products2 = context.products
                     .Include(x => x.category)
+                    .Select(x => new productProxy {
+                        id = x.id,
+                        name = x.name,
+                        category = new categoryProxy {
+                            name = x.name
+                        }
+                    })
                     .OrderBy(x => x.id)
                     .Take(10)
                     .ToList();

--- a/MySql.Bug75272/ProductsTest.cs
+++ b/MySql.Bug75272/ProductsTest.cs
@@ -28,21 +28,35 @@ namespace MySql.Bug75272
 
                 context.Database.Log = q => Console.WriteLine(q);
 
-                //var products1 = context.products
-                //    .OrderBy(x => x.id)
-                //    .Take(10)
-                //    .ToList();
-                
+                // Bug product id long
+                var products1 = context.products
+                    .OrderBy(x => x.id)
+                    .Take(10)
+                    .ToList();
+
+                // Bug product id long
                 var products2 = context.products
+                    .Select(x => new productProxy {
+                        id = x.id,
+                        name = x.name,
+                    })
+                    .Where(x => x.id > 0)
+                    .OrderByDescending(x => x.id)
+                    .Take(10)
+                    .ToList();
+
+                // Bug cateroy id long
+                var products3 = context.products
                     .Include(x => x.category)
                     .Select(x => new productProxy {
                         id = x.id,
                         name = x.name,
                         category = new categoryProxy {
-                            name = x.name
+                            name = x.category.name
                         }
                     })
-                    .OrderBy(x => x.id)
+                    .Where(x => x.id > 0)
+                    .OrderByDescending(x => x.id)
                     .Take(10)
                     .ToList();
 

--- a/MySql.Bug75272/packages.config
+++ b/MySql.Bug75272/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.0.0" targetFramework="net452" />
+  <package id="EntityFramework" version="6.2.0" targetFramework="net452" />
   <package id="MySql.Data" version="6.9.9" targetFramework="net452" />
   <package id="MySql.Data.Entity" version="6.9.9" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Hi, I use "proxy class" to select only a few columns of the table, so long, but using "long" and not "int" in the "id" the bug occurs

`Closed connection at 16/02/2018 12:03:26 -02:00

Opened connection at 16/02/2018 12:03:26 -02:00

SELECT
`Project1`.`C1`, 
`Project1`.`id`, 
`Project1`.`name`
FROM (SELECT
`Extent1`.`id`, 
`Extent1`.`name`, 
1 AS `C1`
FROM `product` AS `Extent1`) AS `Project1`
 ORDER BY 
`Project1`.`id` ASC LIMIT 10


-- Executing at 16/02/2018 12:03:26 -02:00

-- Completed in 0 ms with result: EFMySqlDataReader



Closed connection at 16/02/2018 12:03:26 -02:00`